### PR TITLE
Prevent path traversal in local upload file serving

### DIFF
--- a/XboxDownload/Services/TcpConnectionListener.cs
+++ b/XboxDownload/Services/TcpConnectionListener.cs
@@ -953,9 +953,11 @@ public partial class TcpConnectionListener(ServiceViewModel serviceViewModel)
         localPath = string.Empty;
         if (!serviceViewModel.IsLocalUploadEnabled) return false;
 
-        var directPath = serviceViewModel.LocalUploadPath + requestPath;
+        var basePath = Path.GetFullPath(serviceViewModel.LocalUploadPath);
+        var basePrefix = basePath.EndsWith(Path.DirectorySeparatorChar) ? basePath : basePath + Path.DirectorySeparatorChar;
+        var directPath = Path.GetFullPath(serviceViewModel.LocalUploadPath + requestPath);
         var fileNamePath = Path.Combine(serviceViewModel.LocalUploadPath, Path.GetFileName(requestPath));
-        if (File.Exists(directPath))
+        if (directPath.StartsWith(basePrefix, StringComparison.Ordinal) && File.Exists(directPath))
         {
             localPath = OperatingSystem.IsWindows() ? directPath.Replace("/", "\\") : directPath;
         }


### PR DESCRIPTION
The local upload feature builds the file path by directly concatenating the request path onto LocalUploadPath, so a request like GET /../../../../etc/passwd resolves outside the upload folder and File.Exists/FileStream happily serve it back. Since the TCP listener answers requests from any device on the LAN over both HTTP and HTTPS, this lets anyone read arbitrary files from the host. I canonicalize the combined path with Path.GetFullPath and only serve it when it still lives under LocalUploadPath. The GetFileName fallback was already safe, so normal uploads behave exactly as before.